### PR TITLE
Support get metric for general pql that doesn't depend pod/node resource

### DIFF
--- a/observer-plugins/metric-server/main.go
+++ b/observer-plugins/metric-server/main.go
@@ -86,7 +86,7 @@ func main() {
 // which is closed on one of these signals. If a second signal is caught, the program
 // is terminated with exit code 1.
 func SetupSignalHandler(socketFile string) {
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 2)
 	signal.Notify(c, shutdownSignals...)
 	go func() {
 		for s := range c {

--- a/observer-plugins/metric-server/main.go
+++ b/observer-plugins/metric-server/main.go
@@ -20,6 +20,9 @@ import (
 	"flag"
 	"log"
 	"net"
+	"os"
+	"os/signal"
+	"syscall"
 
 	//"github.com/smoky8/pkg/lib/go/obi"
 	"google.golang.org/grpc"
@@ -36,6 +39,9 @@ var (
 	//metricServer = flag.String("metric-server", "localhost", "metric server address")
 	endpoint   = flag.String("endpoint", "/var/run/observer.sock", "unix socket domain for current server")
 	kubeconfig = flag.String("kubeconfig", "", "kubernetes auth config file")
+)
+var (
+	shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
 )
 
 func main() {
@@ -61,8 +67,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("%s create metric client error: %s", server.PluginName, err)
 	}
-	metricServer := grpc.NewServer()
 
+	// Setup signal watcher to handle cleanup
+	SetupSignalHandler(*endpoint)
+
+	metricServer := grpc.NewServer()
 	obi.RegisterServerServer(metricServer, server.NewServer(clientSet))
 	listen, err := net.Listen("unix", *endpoint)
 	if err != nil {
@@ -71,4 +80,26 @@ func main() {
 	klog.Infof("%s starting work...", server.PluginName)
 
 	klog.Fatalln(metricServer.Serve(listen))
+}
+
+// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupSignalHandler(socketFile string) {
+	c := make(chan os.Signal)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		for s := range c {
+			switch s {
+			case os.Interrupt, syscall.SIGTERM:
+				klog.Infoln("Shutting down normally...")
+				if err := os.RemoveAll(socketFile); err != nil {
+					klog.Fatal(err)
+				}
+				os.Exit(1)
+			default:
+				klog.Infoln("Got signal", s)
+			}
+		}
+	}()
 }

--- a/observer-plugins/prometheus/main.go
+++ b/observer-plugins/prometheus/main.go
@@ -20,6 +20,9 @@ import (
 	"flag"
 	"log"
 	"net"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"google.golang.org/grpc"
 	"k8s.io/client-go/kubernetes"
@@ -37,6 +40,9 @@ var (
 	address     = flag.String("address", "", "prometheus server, such as http://localhost:9090")
 	stepSeconds = flag.Int64("step", 60, "query steps")
 	rangeMinute = flag.Int64("range", 2, "prometheus, the maximum time between two slices within the boundaries.")
+)
+var (
+	shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
 )
 
 func main() {
@@ -64,6 +70,8 @@ func main() {
 	if err != nil {
 		klog.Fatal(err)
 	}
+	// Setup signal watcher to handle cleanup
+	SetupSignalHandler(*endpoint)
 
 	server := grpc.NewServer()
 	obi.RegisterServerServer(server, prometheus.NewPrometheusServer(*address, conf, *stepSeconds, *rangeMinute))
@@ -72,6 +80,28 @@ func main() {
 		log.Fatal(err)
 	}
 
-	klog.Infof("%s starting work...", prometheus.PluginName)
+	klog.Infof("%s plugin started ...", prometheus.PluginName)
 	klog.Fatalln(server.Serve(listen))
+}
+
+// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupSignalHandler(socketFile string) {
+	c := make(chan os.Signal)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		for s := range c {
+			switch s {
+			case os.Interrupt, syscall.SIGTERM:
+				klog.Infoln("Shutting down normally...")
+				if err := os.RemoveAll(socketFile); err != nil {
+					klog.Fatal(err)
+				}
+				os.Exit(1)
+			default:
+				klog.Infoln("Got signal", s)
+			}
+		}
+	}()
 }

--- a/observer-plugins/prometheus/main.go
+++ b/observer-plugins/prometheus/main.go
@@ -88,7 +88,7 @@ func main() {
 // which is closed on one of these signals. If a second signal is caught, the program
 // is terminated with exit code 1.
 func SetupSignalHandler(socketFile string) {
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 2)
 	signal.Notify(c, shutdownSignals...)
 	go func() {
 		for s := range c {


### PR DESCRIPTION
#### What type of PR is this?
1. Remove the socket file during server shutdown
2. Support to get general metrics that does not depend on pod/node with empty/other kind in the OBI

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
